### PR TITLE
fix: parse dynamic imports with webpack magic comments

### DIFF
--- a/parseImports.go
+++ b/parseImports.go
@@ -246,12 +246,13 @@ func parseExpression(code []byte, i int) (string, int, int, int) {
 			continue
 		}
 
-		skippedSpacesIndex := skipSpaces(code, i)
-		if skippedSpacesIndex == i {
+		// Skip whitespace and comments (e.g. /* webpackChunkName: "..." */) to reach the string literal
+		skippedIndex := skipSpacesAndComments(code, i)
+		if skippedIndex == i {
 			// If there was any valid import the loop should break already
 			return "", i, 0, 0
 		}
-		i = skippedSpacesIndex
+		i = skippedIndex
 	}
 	if moduleStart == -1 || moduleEnd == -1 {
 		return string(module), i, 0, 0

--- a/parseImports_test.go
+++ b/parseImports_test.go
@@ -2660,6 +2660,17 @@ const m = import('./real-dynamic')
 	}
 }
 
+func TestDynamicImportWithWebpackMagicComment(t *testing.T) {
+	code := `const View = lazy(() => import(/* webpackChunkName: "lazy-view" */ '@scope/app/components/views/summary-view'))`
+	imports := ParseImportsByte([]byte(code), false, ParseModeBasic)
+	if len(imports) != 1 {
+		t.Fatalf("Expected 1 import, got %d: %+v", len(imports), imports)
+	}
+	if imports[0].Request != "@scope/app/components/views/summary-view" || !imports[0].IsDynamicImport {
+		t.Fatalf("Expected dynamic import with webpack comment, got request=%q dynamic=%v", imports[0].Request, imports[0].IsDynamicImport)
+	}
+}
+
 func TestMemberImportCallWithSpacesAfterDotIsNotDynamicImport(t *testing.T) {
 	code := `
 const Module = {}


### PR DESCRIPTION
## Problem

When parsing dynamic imports like `import(/* webpackChunkName: "..." */ 'path')`, rev-dep used `skipSpaces` to advance past whitespace between `import(` and the path string. Block comments (e.g. webpack magic comments) were not skipped, causing the parser to fail or return incorrect results.

## Solution

Use `skipSpacesAndComments` instead of `skipSpaces` so block comments between `import(` and the module path string are correctly skipped.

## Testing

- `go test -run TestDynamicImportWithWebpackMagicComment ./...` passes