### PR TITLE
Fix root-anchored glob patterns matching nested directories

### DIFF
--- a/createGlobMatchers.go
+++ b/createGlobMatchers.go
@@ -89,8 +89,8 @@ func MatchesAnyGlobMatcher(filePath string, matchers []GlobMatcher, debug bool) 
 			}
 			return true
 		}
-		if matcher.shouldMatchAnyFileOrDirWithPattern && strings.HasSuffix(fileWithoutPrefix, "/"+matcher.inputString) {
-			// matches file with name exactly as the pattern
+		if matcher.shouldMatchAnyFileOrDirWithPattern && !matcher.isAnchoredToPatternRoot && strings.HasSuffix(fileWithoutPrefix, "/"+matcher.inputString) {
+			// matches file/dir with name exactly as the pattern (unnanchored only - anchored patterns like /boot must only match at root)
 			if debug {
 				fmt.Println(fileWithoutPrefix, "return matches file name exactly", matcher.inputString)
 			}

--- a/createGlobMatchers_test.go
+++ b/createGlobMatchers_test.go
@@ -166,4 +166,17 @@ func TestGlobMatchingWithRootAnchoredPattern(t *testing.T) {
 			t.Errorf(`Pattern "%s" is matching path "%s" but it should not`, pattern, filePath)
 		}
 	})
+
+	t.Run("Root-anchored /config should not match nested directory", func(t *testing.T) {
+		root := "/fs/root/"
+		pattern := "/config"
+		filePath := "/fs/root/js/projects/app/config"
+		globMatchers := CreateGlobMatchers([]string{pattern}, root)
+
+		matches := MatchesAnyGlobMatcher(filePath, globMatchers, debug)
+
+		if matches {
+			t.Errorf(`Pattern "%s" is matching path "%s" but it should not`, pattern, filePath)
+		}
+	})
 }


### PR DESCRIPTION
### Summary

Root-anchored glob patterns (e.g. `/boot`, `/config`) were incorrectly matching nested directories with the same name (e.g. `js/projects/app/config`) instead of only matching at the root.

### Root cause

The `HasSuffix` check for exact directory/file name matching didn't account for `isAnchoredToPatternRoot`, so anchored patterns were incorrectly matching nested paths ending with the pattern name.

### Changes

- Add `!matcher.isAnchoredToPatternRoot` guard so anchored patterns only match at root
- Add test case: `Root-anchored /config should not match nested directory`

### Testing

- New test fails without the fix, passes with it
- All existing glob matcher tests pass