### PR TITLE
fix: fall back to tsconfig paths when workspace resolution fails

### DIFF
--- a/monorepo_resolution_test.go
+++ b/monorepo_resolution_test.go
@@ -978,3 +978,85 @@ func TestMonorepoImportAliasToWorkspacePackage(t *testing.T) {
 	}
 
 }
+
+// TestWorkspaceFallbackToTsconfig covers the bug where workspace resolution matched
+// but failed (e.g. FileNotFound for packages without exports), and we returned immediately
+// without trying tsconfig paths. Now we fall through to tsconfig when workspace fails.
+func TestWorkspaceFallbackToTsconfig(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "rev-dep-monorepo-workspace-fallback")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Workspace package @company/common has NO exports. resolvePackageFallback builds
+	// pkgPath + subpath = packages/common/components/utils (wrong).
+	// The actual file lives at packages/common/src/components/utils.ts.
+	// The app's tsconfig maps @company/common/* -> ../../packages/common/src/*.
+	files := map[string]string{
+		"package.json": `{ "workspaces": ["packages/*", "apps/*"] }`,
+		"packages/common/package.json": `{
+			"name": "@company/common",
+			"version": "1.0.0"
+		}`,
+		"packages/common/src/components/utils.ts": `export const util = {};`,
+		"apps/app/package.json": `{
+			"name": "app",
+			"dependencies": {
+				"@company/common": "*"
+			}
+		}`,
+		"apps/app/tsconfig.json": `{
+			"compilerOptions": {
+				"baseUrl": ".",
+				"paths": {
+					"@company/common/*": ["../../packages/common/src/*"]
+				}
+			}
+		}`,
+		"apps/app/src/index.ts": `import { util } from "@company/common/components/utils";`,
+	}
+
+	for path, content := range files {
+		fullPath := filepath.Join(tmpDir, path)
+		os.MkdirAll(filepath.Dir(fullPath), 0755)
+		os.WriteFile(fullPath, []byte(content), 0644)
+	}
+
+	cwd := filepath.Join(tmpDir, "apps/app")
+	allKeys := []string{}
+	for k := range files {
+		if filepath.Ext(k) == ".ts" || filepath.Ext(k) == ".js" || filepath.Ext(k) == ".json" {
+			allKeys = append(allKeys, filepath.Join(tmpDir, k))
+		}
+	}
+
+	rootParams := RootParams{
+		TsConfigContent: []byte(files["apps/app/tsconfig.json"]),
+		PkgJsonContent:  []byte(files["apps/app/package.json"]),
+		SortedFiles:     allKeys,
+		Cwd:             cwd,
+	}
+
+	manager := NewResolverManager(FollowMonorepoPackagesValue{FollowAll: true}, []string{"import", "default", "node"}, rootParams, []GlobMatcher{})
+	appFile := filepath.Join(cwd, "src/index.ts")
+	resolver := manager.GetResolverForFile(appFile)
+
+	// Without the fix: workspace matches but returns FileNotFound (wrong path),
+	// and we would return that error. With the fix: we fall through to tsconfig
+	// and resolve correctly to packages/common/src/components/utils.ts
+	path, rtype, resErr := resolver.ResolveModule("@company/common/components/utils", appFile)
+
+	if resErr != nil {
+		t.Fatalf("Expected resolution to succeed via tsconfig fallback, got error: %v", *resErr)
+	}
+	expected := filepath.Join(tmpDir, "packages/common/src/components/utils.ts")
+	if path != expected {
+		t.Errorf("Expected path %s, got %s", expected, path)
+	}
+	// Resolved via tsconfig paths, so UserModule (tsconfig aliases are UserModule)
+	if rtype != UserModule {
+		t.Errorf("Expected UserModule for tsconfig resolution, got %v", rtype)
+	}
+}
+

--- a/resolveImports.go
+++ b/resolveImports.go
@@ -1224,10 +1224,13 @@ func (f *ModuleResolver) ResolveModule(request string, filePath string) (path st
 	}
 
 	// Try workspace package resolution for the original request before TypeScript alias resolution
-	// to ensure monorepo packages take precedence over TypeScript aliases
-	// But only if no package.json import was matched
+	// to ensure monorepo packages take precedence over TypeScript aliases.
+	// But only if no package.json import was matched.
+	// If workspace resolution matches but fails (e.g. FileNotFound for packages without exports),
+	// fall through to tsconfig paths instead of returning the error.
 	if aliasMatchedButFileNotFound == "" {
-		if requestMatched, resolvedPath, rtype, err := f.tryResolveWorkspacePackageImport(requestWithoutQuery, root); requestMatched {
+		// Fall through to tsconfig paths when workspace matches but resolution fails
+		if requestMatched, resolvedPath, rtype, err := f.tryResolveWorkspacePackageImport(requestWithoutQuery, root); requestMatched && err == nil {
 			return resolvedPath, rtype, err
 		}
 	}


### PR DESCRIPTION
## Summary

When workspace package resolution matched but failed (e.g. `FileNotFound` for packages without an `exports` field), the resolver returned immediately instead of trying tsconfig `paths` as fallback. This fix lets it fall through to tsconfig resolution in those cases.

## Problem

For monorepo packages without `exports`, `resolvePackageFallback` builds the wrong path (e.g. `packages/common/components/utils` instead of `packages/common/src/components/utils.ts`). Workspace resolution matched but returned `FileNotFound`, and we surfaced that error instead of using the app's tsconfig `paths` mapping.

## Solution

Only return early from workspace resolution when both the request matches and resolution succeeds (`requestMatched && err == nil`). If workspace matches but fails, fall through to tsconfig paths and resolve via the app's path mappings.

## Changes

- **resolveImports.go**: Add `err == nil` to the workspace resolution early-return condition so we fall through to tsconfig when workspace fails
- **monorepo_resolution_test.go**: Add `TestWorkspaceFallbackToTsconfig` covering the `@company/common/components/utils` → tsconfig fallback scenario